### PR TITLE
Refined requirements: pathlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ arrow
 pytz
 tzlocal
 sh
-pathlib
+pathlib; python_version < "3.4"
 tabulate
 requests
 xtract


### PR DESCRIPTION
pathlib is necessary only for python_version < 3.4.
This can fix #6 

